### PR TITLE
Set tikzcd background colour in environment boxes

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -71,15 +71,19 @@
       add to width=1.1mm,
       enlarge left by=-0.6mm}
   }
+  \newcommand{\setenvcolor}[2]{%
+      \tcolorboxenvironment{#1}{shadedenv={#2}}
+      \addtotheorempreheadhook[#1]{\tikzcdset{background color=#2}}
+  }
   %
-  \tcolorboxenvironment{theorem}    {shadedenv={ShadeOfPurple}}
-  \tcolorboxenvironment{lemma}      {shadedenv={ShadeOfPurple}}
-  \tcolorboxenvironment{proposition}{shadedenv={ShadeOfPurple}}
-  \tcolorboxenvironment{corollary}  {shadedenv={ShadeOfPurple}}
-  \tcolorboxenvironment{definition} {shadedenv={ShadeOfYellow}}
-  \tcolorboxenvironment{example}    {shadedenv={ShadeOfGreen}}
-  \tcolorboxenvironment{remark}     {shadedenv={ShadeOfBrown}}
-  \tcolorboxenvironment{proof}      {shadedenv={ShadeOfGray}}
+  \setenvcolor{theorem}{ShadeOfPurple}
+  \setenvcolor{lemma}{ShadeOfPurple}
+  \setenvcolor{proposition}{ShadeOfPurple}
+  \setenvcolor{corollary}{ShadeOfPurple}
+  \setenvcolor{definition}{ShadeOfYellow}
+  \setenvcolor{example}{ShadeOfGreen}
+  \setenvcolor{remark}{ShadeOfBrown}
+  \setenvcolor{proof}{ShadeOfGray}
 }{% Use closing symbols if we don't have colours
   \declaretheorem[sibling=equation]{theorem}
   \declaretheorem[sibling=theorem]{lemma,proposition,corollary}

--- a/mainmatter/chapter.tex
+++ b/mainmatter/chapter.tex
@@ -23,6 +23,21 @@ reference to a result, see~\cref{thm} below.
   \nomenclature[C]{$\mathcal C$}{a category}
 \end{proposition}
 
+\lipsum[1]
+
+\begin{theorem}[Triangle equation]
+  The following diagram commutes:
+  \begin{center}
+    \begin{tikzcd}
+      A \arrow[equal]{rr}\arrow{dr}{f} & & A \\
+      & B \arrow{ur}{g} &
+    \end{tikzcd}
+  \end{center}
+\end{theorem}
+\begin{proof}
+  Trivial.
+\end{proof}
+
 \section{Definitions, theorems and proofs}
 
 \lipsum[4]


### PR DESCRIPTION
An annoying quirk of tikzcd is that it colours in the insides of its 'equal' arrows (and no doubt other things I haven't encountered). This clashes with the coloured backgrounds of environments.

This pull request fixes this by adding a pre-hook that sets the tikzcd `background color` option.