### PR TITLE
Separate formatting from content, use standard document macros

### DIFF
--- a/frontmatter/titlepage.tex
+++ b/frontmatter/titlepage.tex
@@ -1,11 +1,12 @@
 \newgeometry{total={180mm,267mm}} % Make "A thesis submitted...the degree of" fit one line
+  \makeatletter
 \begin{titlepage}
 \begin{center}
   \vspace*{\stretch{0.5}}
 
   \large % Default size for the title page
 
-  {\Huge\textsc{The Title of a PhD Thesis}\par}
+  {\Huge\textsc{\@title}\par}
 
   \vspace{\stretch{0.2}}
 
@@ -13,20 +14,22 @@
 
   \vspace{\stretch{0.2}}
 
-  {\huge\textsc{Jane Doe}}
+  {\huge\textsc{\@author}}
+
 
   \vspace{\stretch{0.5}}
 
-  A thesis submitted to the University of Foo for the degree of\\
-  \textsc{Doctor of Philosophy}
+    A thesis submitted to the \@institution{} for the degree of\\
+  \textsc{\@degree}
 
   \vfill
 
   \flushright
-  School of Bar \\
-  College of Baz and Quz \\
-  University of Foo \\
-  January 2023
+    \@ifundefined{@school}{}{\@school \\}
+    \@ifundefined{@college}{}{\@college \\}
+    \@institution \\
+    \@date
 
 \end{center}
 \end{titlepage}
+  \makeatother

--- a/main.tex
+++ b/main.tex
@@ -105,6 +105,13 @@
 % because we prefer to keep up the tradition.
 
 
+\title{The Title of a PhD Thesis}
+\author{Jane Doe}
+\institution{University of Foo}
+\degree{Doctor of Philosophy}
+%\school{School of Bar}
+%\college{College of Baz and Quz}
+%\date{January 2023}
 
 \begin{document}
 

--- a/main.tex
+++ b/main.tex
@@ -4,107 +4,6 @@
 \usepackage{packages}
 \usepackage{macros}
 
-% Label tables just like equations, theorems, definitions, etc.
-%
-% NB: This can be confusing if LaTeX does not place the table at the point of
-% writing (e.g. for lack of space)!
-\numberwithin{equation}{section}
-\numberwithin{table}{section}
-\makeatletter
-\let\c@equation\c@table
-\makeatother
-
-% Setting up the coloured environments
-%
-\newbool{shade-envs}
-% This can be used to toggle the coloured environments on or off.
-\setboolean{shade-envs}{true}
-
-%%
-\ifthenelse{\boolean{shade-envs}}{%
-  % Colours are as in Andrej Bauer's notes on realizability:
-  % https://github.com/andrejbauer/notes-on-realizability
-  \colorlet{ShadeOfPurple}{blue!5!white}
-  \colorlet{ShadeOfYellow}{yellow!5!white}
-  \colorlet{ShadeOfGreen} {green!5!white}
-  \colorlet{ShadeOfBrown} {brown!10!white}
-  % But we also shade proofs
-  \colorlet{ShadeOfGray}  {gray!10!white}
-}
-% If we don't want to have shaded environments, then we use a closing symbol
-% \lozenge to mark the end of remarks, definitions and examples.
-{%
-  \declaretheoremstyle[
-      spaceabove=6pt,
-      spacebelow=6pt,
-      bodyfont=\normalfont,
-      qed=\(\lozenge\)
-  ]{definitionwithbox}
-  \declaretheoremstyle[
-      headfont=\itshape,
-      bodyfont=\normalfont,
-      qed=\(\lozenge\)
-      ]{remarkwithbox}
-}
-
-\ifthenelse{\boolean{shade-envs}}{%
-  \declaretheorem[sibling=equation]{theorem}
-  \declaretheorem[sibling=theorem]{lemma,proposition,corollary}
-  \declaretheorem[sibling=theorem,style=definition]{definition}
-  \declaretheorem[sibling=theorem,style=definition]{example}
-  \declaretheorem[sibling=theorem,style=remark]{remark}
-  % Now we set the shading using the tcolorbox package.
-  %
-  % The related thmtools' option "shaded" and the package mdframed seem to have
-  % issues: the former does not allow for page breaks in shaded environments and
-  % the latter puts double spacing between two shaded environments.
-  %
-  % Since tcolorbox puts stuff inside a minipage or \parbox (according to this
-  % stackexchange answer: https://tex.stackexchange.com/a/250170), new
-  % paragraphs aren't indented. We can fix this by grabbing the parindent
-  % value and passing it to tcbset.
-  \newlength{\normalparindent}
-  \AtBeginDocument{\setlength{\normalparindent}{\parindent}}
-  \tcbset{shadedenv/.style={
-      colback={#1},
-      frame hidden,
-      enhanced,
-      breakable,
-      boxsep=0pt,
-      left=2mm,
-      right=2mm,
-      % LaTeX thinks this is too wide (as becomes clear from the many "Overfull
-      % \hbox" warnings, but optically it looks spot on.
-      add to width=1.1mm,
-      enlarge left by=-0.6mm,
-      before upper={\setlength{\parindent}{\normalparindent}}}
-  }
-  \newcommand{\setenvcolor}[2]{%
-      \tcolorboxenvironment{#1}{shadedenv={#2}}
-      \addtotheorempreheadhook[#1]{\tikzcdset{background color=#2}}
-  }
-  %
-  \setenvcolor{theorem}{ShadeOfPurple}
-  \setenvcolor{lemma}{ShadeOfPurple}
-  \setenvcolor{proposition}{ShadeOfPurple}
-  \setenvcolor{corollary}{ShadeOfPurple}
-  \setenvcolor{definition}{ShadeOfYellow}
-  \setenvcolor{example}{ShadeOfGreen}
-  \setenvcolor{remark}{ShadeOfBrown}
-  \setenvcolor{proof}{ShadeOfGray}
-}{% Use closing symbols if we don't have colours
-  \declaretheorem[sibling=equation]{theorem}
-  \declaretheorem[sibling=theorem]{lemma,proposition,corollary}
-  \declaretheorem[sibling=theorem,style=definitionwithbox]{definition}
-  \declaretheorem[sibling=theorem,style=definitionwithbox]{example}
-  \declaretheorem[sibling=theorem,style=remarkwithbox]{remark}
-  }
-\declaretheorem[sibling=theorem,style=remark,numbered=no]{claim}
-
-% Note that proofs will still have the \qed symbol at the end, even when shaded,
-% because we prefer to keep up the tradition.
-
-
 \title{The Title of a PhD Thesis}
 \author{Jane Doe}
 \institution{University of Foo}
@@ -123,7 +22,6 @@
 \include{frontmatter/abstract}
 \include{frontmatter/acknowledgements}
 
-\setcounter{tocdepth}{2}
 \tableofcontents
 
 \mainmatter%

--- a/main.tex
+++ b/main.tex
@@ -8,9 +8,11 @@
 \author{Jane Doe}
 \institution{University of Foo}
 \degree{Doctor of Philosophy}
-%\school{School of Bar}
-%\college{College of Baz and Quz}
+%\school{School of Bar}    % optional
+%\college{College of Baz and Quz}    % optional
 %\date{January 2023}
+%\subject{PhD thesis}    % optional
+%\keywords{some, descriptive, keywords}
 
 \begin{document}
 

--- a/packages.sty
+++ b/packages.sty
@@ -155,3 +155,107 @@ backrefstyle=two]%
 
 \usepackage[noabbrev,capitalize]{cleveref}
 \creflabelformat{equation}{#2\textup{#1}#3} % Write Equation x.y.z instead of Equation (x.y.z)
+
+% Label tables just like equations, theorems, definitions, etc.
+%
+% NB: This can be confusing if LaTeX does not place the table at the point of
+% writing (e.g. for lack of space)!
+\numberwithin{equation}{section}
+\numberwithin{table}{section}
+\makeatletter
+\let\c@equation\c@table
+\makeatother
+
+% Setting up the coloured environments
+%
+\newbool{shade-envs}
+% This can be used to toggle the coloured environments on or off.
+\setboolean{shade-envs}{true}
+
+%%
+\ifthenelse{\boolean{shade-envs}}{%
+  % Colours are as in Andrej Bauer's notes on realizability:
+  % https://github.com/andrejbauer/notes-on-realizability
+  \colorlet{ShadeOfPurple}{blue!5!white}
+  \colorlet{ShadeOfYellow}{yellow!5!white}
+  \colorlet{ShadeOfGreen} {green!5!white}
+  \colorlet{ShadeOfBrown} {brown!10!white}
+  % But we also shade proofs
+  \colorlet{ShadeOfGray}  {gray!10!white}
+}
+% If we don't want to have shaded environments, then we use a closing symbol
+% \lozenge to mark the end of remarks, definitions and examples.
+{%
+  \declaretheoremstyle[
+      spaceabove=6pt,
+      spacebelow=6pt,
+      bodyfont=\normalfont,
+      qed=\(\lozenge\)
+  ]{definitionwithbox}
+  \declaretheoremstyle[
+      headfont=\itshape,
+      bodyfont=\normalfont,
+      qed=\(\lozenge\)
+      ]{remarkwithbox}
+}
+
+\ifthenelse{\boolean{shade-envs}}{%
+  \declaretheorem[sibling=equation]{theorem}
+  \declaretheorem[sibling=theorem]{lemma,proposition,corollary}
+  \declaretheorem[sibling=theorem,style=definition]{definition}
+  \declaretheorem[sibling=theorem,style=definition]{example}
+  \declaretheorem[sibling=theorem,style=remark]{remark}
+  % Now we set the shading using the tcolorbox package.
+  %
+  % The related thmtools' option "shaded" and the package mdframed seem to have
+  % issues: the former does not allow for page breaks in shaded environments and
+  % the latter puts double spacing between two shaded environments.
+  %
+  % Since tcolorbox puts stuff inside a minipage or \parbox (according to this
+  % stackexchange answer: https://tex.stackexchange.com/a/250170), new
+  % paragraphs aren't indented. We can fix this by grabbing the parindent
+  % value and passing it to tcbset.
+  \newlength{\normalparindent}
+  \AtBeginDocument{\setlength{\normalparindent}{\parindent}}
+  \tcbset{shadedenv/.style={
+      colback={#1},
+      frame hidden,
+      enhanced,
+      breakable,
+      boxsep=0pt,
+      left=2mm,
+      right=2mm,
+      % LaTeX thinks this is too wide (as becomes clear from the many "Overfull
+      % \hbox" warnings, but optically it looks spot on.
+      add to width=1.1mm,
+      enlarge left by=-0.6mm,
+      before upper={\setlength{\parindent}{\normalparindent}}}
+  }
+  \newcommand{\setenvcolor}[2]{%
+      \tcolorboxenvironment{#1}{shadedenv={#2}}
+      \addtotheorempreheadhook[#1]{\tikzcdset{background color=#2}}
+  }
+  %
+  \setenvcolor{theorem}{ShadeOfPurple}
+  \setenvcolor{lemma}{ShadeOfPurple}
+  \setenvcolor{proposition}{ShadeOfPurple}
+  \setenvcolor{corollary}{ShadeOfPurple}
+  \setenvcolor{definition}{ShadeOfYellow}
+  \setenvcolor{example}{ShadeOfGreen}
+  \setenvcolor{remark}{ShadeOfBrown}
+  \setenvcolor{proof}{ShadeOfGray}
+}{% Use closing symbols if we don't have colours
+  \declaretheorem[sibling=equation]{theorem}
+  \declaretheorem[sibling=theorem]{lemma,proposition,corollary}
+  \declaretheorem[sibling=theorem,style=definitionwithbox]{definition}
+  \declaretheorem[sibling=theorem,style=definitionwithbox]{example}
+  \declaretheorem[sibling=theorem,style=remarkwithbox]{remark}
+  }
+\declaretheorem[sibling=theorem,style=remark,numbered=no]{claim}
+
+% Note that proofs will still have the \qed symbol at the end, even when shaded,
+% because we prefer to keep up the tradition.
+
+
+% Set table of contents depth
+\setcounter{tocdepth}{2}

--- a/packages.sty
+++ b/packages.sty
@@ -126,14 +126,32 @@ backrefstyle=two]%
 , linkcolor=NavyBlue    % Colour for internal links
 , citecolor=Green  % Colour for bibliographical citations
 , urlcolor=BrickRed % Colour for (external) urls
-%
-% Metadata
-%
-, pdftitle={The Title of a PhD Thesis}%
-, pdfauthor={Jane Doe}%
-, pdfsubject={PhD thesis}%
-, pdfkeywords={some, descriptive, keywords}
 ]{hyperref}
+
+
+% Metadata setup (define using \subject, \degree, \institution, etc. in main.tex)
+\makeatletter
+
+\newcommand{\subject}[1]{\gdef\@subject{#1}}%
+\newcommand{\@subject}{PhD thesis} 
+\newcommand{\degree}[1]{\gdef\@degree{#1}}%
+\newcommand{\@degree}{Doctor of Philosophy}
+\newcommand{\institution}[1]{\gdef\@institution{#1}}%
+\newcommand{\@institution}{University of Foo}
+\newcommand{\school}[1]{\gdef\@school{#1}}%
+\newcommand{\college}[1]{\gdef\@college{#1}}%
+\newcommand{\keywords}[1]{\gdef\@keywords{#1}}%
+\newcommand{\@keywords}{some, descriptive, keywords} 
+
+\AtBeginDocument{
+  \hypersetup{
+    pdftitle = {\@title},
+    pdfauthor = {\@author},
+    pdfsubject = {\@subject},
+    pdfkeywords = {\@keywords}
+  }
+}
+\makeatother
 
 \usepackage[noabbrev,capitalize]{cleveref}
 \creflabelformat{equation}{#2\textup{#1}#3} % Write Equation x.y.z instead of Equation (x.y.z)


### PR DESCRIPTION
## Problem
Current implementation intermingles formatting/display settings and content:

- `main.tex` contains both formatting code (e.g. definition of shade colours) and content. `packages.sty` contains both formatting code and content (the metadata definitions). `frontmatter/titlepage.tex` contains both formatting code (defining the look of the title page) and content (the title, author, date, school, college, university).
- title and author have to be defined twice (in `frontmatter/titlepage.tex` for display and `packages.sty` for metadata), neither of which is the most sensible place a user would expect (`main.tex`).
- title and author aren't available as macros, e.g. if a user wanted to display either in the page header by modifying `\fancyhead[R]` or `\fancyhead[L]` in `packages.sty`.


## Solution

- Encode key aspects of document via macros defined in `main.tex`
    - `\title`, `\author`, `\date` have their usual meaning. All three displayed on title page. Compilation fails if no `title` given; if no `author` given, defaults to empty string in display and 'None' in metadata; if no `date` given, defaults to today's date.
    -  `\institution` for defining the university name (default: "University of Foo")
    -  `\college` for the college name, and `\school` for the school name. If undefined, then these are not displayed on titlepage (no default)
    - `\degree` defines the full degree title displayed on the title page (default: "Doctor of Philosophy")
    - `\subject` defines the `pdfsubject` included as metadata (default: "PhD thesis")
    - `\keywords` defines the keywords included in metadata (default: "some, descriptive, keywords")
- No content defined in `frontmatter/titlepage.tex` or `packages.sty`. Title page and metadata pull from the macros defined in `main.tex`.
- Moved styling/display settings out of `main.tex` and to the end of `packages.sty`. Now `main.tex` just defines the top-level layout of the document, with all the formatting defined in `packages.sty`.